### PR TITLE
Feat/#2 UI home 및 main 구현

### DIFF
--- a/eatmoji/package-lock.json
+++ b/eatmoji/package-lock.json
@@ -18,9 +18,11 @@
         "@types/node": "^20.17.50",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
-        "tailwindcss": "^4",
+        "postcss": "^8.5.4",
+        "tailwindcss": "^4.1.8",
         "typescript": "^5.8.3"
       }
     },
@@ -546,6 +548,13 @@
         "tailwindcss": "4.1.7"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.7",
       "dev": true,
@@ -799,6 +808,13 @@
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.7"
       }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -1300,6 +1316,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "dev": true,
@@ -1353,6 +1407,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
+      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001718",
+        "electron-to-chromium": "^1.5.160",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/busboy": {
@@ -1659,6 +1746,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.161",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.161.tgz",
+      "integrity": "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "dev": true,
@@ -1832,6 +1926,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2342,6 +2446,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/function-bind": {
@@ -3565,6 +3683,23 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "dev": true,
@@ -3788,7 +3923,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
       "funding": [
         {
@@ -3806,13 +3943,20 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4792,7 +4936,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.7",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
       "dev": true,
       "license": "MIT"
     },
@@ -5270,6 +5416,37 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/eatmoji/package.json
+++ b/eatmoji/package.json
@@ -19,9 +19,11 @@
     "@types/node": "^20.17.50",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
-    "tailwindcss": "^4",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^4.1.8",
     "typescript": "^5.8.3"
   }
 }

--- a/eatmoji/postcss.config.mjs
+++ b/eatmoji/postcss.config.mjs
@@ -1,5 +1,9 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+  theme: {
+    extend: {},
+  },
 };
-
-export default config;

--- a/eatmoji/src/components/global-layout.module.css
+++ b/eatmoji/src/components/global-layout.module.css
@@ -12,23 +12,35 @@
   bottom: 0px;
   width: 411.4px;
   height: 80px;
-  background-color: white;
-  border-top: 2px solid #d1d5db; /* Tailwind gray-300 */
+  background: linear-gradient(to top, #faf8f2, #f5f3ec);;
+  border-top: 1px solid #e0e0e0; /* Tailwind gray-300 */
+  box-shadow: 0 -4px 10px rgba(0, 0, 0, 0.05);
   display: flex;
   justify-content: space-around;
   align-items: center;
+  z-index: 10;
 }
 
 .link {
-  color: #7d8289; /* Tailwind gray-700 */
+  color: #8b8e94; /* Tailwind gray-700 */
   font-family: 'Inter', sans-serif;
-  font-size: 18px;
+  font-size: 17px;
+  font-weight: 400;
+  letter-spacing: 0.3px;
   text-decoration: none;
-  transition: color 0.2s ease-in-out;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: all 0.2s ease-in-out;
 }
 
-.link:hover, 
+.link:hover {
+  color: #222222;
+  background-color: rgba(0, 0, 0, 0.05);
+  font-weight: 500;
+}
+
 .active {
   color: #000000;
-  font-weight: 500;
+  font-weight: 600;
+  background-color: rgba(0, 0, 0, 0.08);
 }

--- a/eatmoji/src/components/global-layout.module.css
+++ b/eatmoji/src/components/global-layout.module.css
@@ -1,0 +1,34 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.main {
+  flex-grow: 1;
+}
+
+.nav {
+  position: fixed;
+  bottom: 0px;
+  width: 411.4px;
+  height: 80px;
+  background-color: white;
+  border-top: 2px solid #d1d5db; /* Tailwind gray-300 */
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.link {
+  color: #7d8289; /* Tailwind gray-700 */
+  font-family: 'Inter', sans-serif;
+  font-size: 18px;
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+}
+
+.link:hover, 
+.active {
+  color: #000000;
+  font-weight: 500;
+}

--- a/eatmoji/src/components/global-layout.tsx
+++ b/eatmoji/src/components/global-layout.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+import style from './global-layout.module.css'
+import { usePathname } from 'next/navigation';
+
+export default function Layout({ children } : { children: ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <div className={style.container}>
+      <main className={style.main}>{children}</main>
+
+      <nav className={style.nav}>
+        <Link href="/search" className={`${style.link} ${pathname === '/search' ? style.active : ''}`}>오메추</Link>
+        <Link href="/" className={`${style.link} ${pathname === '/' ? style.active : ''}`}>홈</Link>
+        <Link href="/profile" className={`${style.link} ${pathname === '/profile' ? style.active : ''}`}>기록</Link>
+      </nav>
+    </div>
+  );
+}

--- a/eatmoji/src/components/global-layout.tsx
+++ b/eatmoji/src/components/global-layout.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 import style from './global-layout.module.css'
-import { usePathname } from 'next/navigation';
+import { useRouter } from 'next/router';
 
 export default function Layout({ children } : { children: ReactNode }) {
-  const pathname = usePathname();
+  const { pathname } = useRouter();
 
   return (
     <div className={style.container}>

--- a/eatmoji/src/components/main-steps/loading.tsx
+++ b/eatmoji/src/components/main-steps/loading.tsx
@@ -1,0 +1,20 @@
+import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
+
+export default function Loading() {
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
+        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        Loading...
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/components/main-steps/step1.tsx
+++ b/eatmoji/src/components/main-steps/step1.tsx
@@ -15,7 +15,7 @@ export default function Step1({nextStep, setAnswer1} : {nextStep: () => void, se
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
+      <div className={`${sharedStyle.sharedContainer} gap-[103px]`}>
         <h1 className="text-2xl font-bold text-gray-800">오늘 하루, 어땠어?</h1>
         <div className="flex flex-col items-center gap-[20px]">
             {["기쁨", "슬픔", "화남", "편안", "아픔"].map((emotion) => (

--- a/eatmoji/src/components/main-steps/step1.tsx
+++ b/eatmoji/src/components/main-steps/step1.tsx
@@ -1,0 +1,34 @@
+import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
+
+export default function Step1({nextStep, setAnswer1} : {nextStep: () => void, setAnswer1: (answer: string) => void}) {
+    const handleClick = (answer: string) => {
+        setAnswer1(answer);
+        nextStep();
+    };
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
+        <h1 className="text-2xl font-bold text-gray-800">오늘 하루, 어땠어?</h1>
+        <div className="flex flex-col items-center gap-[20px]">
+            {["기쁨", "슬픔", "화남", "편안", "아픔"].map((emotion) => (
+            <button
+                key={emotion}
+                className="w-[280px] h-[60px] px-4 py-2 text-gray-800 font-inter text-[20px] font-semibold rounded-2xl bg-[#f5eee0] hover:bg-[#e8dfcf] transition-all duration-200 shadow-[0_2px_6px_rgba(0,0,0,0.1)] hover:shadow-[0_4px_12px_rgba(0,0,0,0.2)] focus:outline-none focus:ring-2 focus:ring-[#d1c8b0]"
+                onClick={() => handleClick(emotion)}
+            >
+                {emotion}
+            </button>
+            ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/components/main-steps/step2.tsx
+++ b/eatmoji/src/components/main-steps/step2.tsx
@@ -1,0 +1,20 @@
+import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
+
+export default function Step2() {
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
+        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        step2입니다.
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/components/main-steps/step3.tsx
+++ b/eatmoji/src/components/main-steps/step3.tsx
@@ -1,0 +1,20 @@
+import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
+
+export default function Step3() {
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
+        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        step3입니다.
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/pages/_app.tsx
+++ b/eatmoji/src/pages/_app.tsx
@@ -1,8 +1,19 @@
 import Layout from "@/components/global-layout";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
 
 export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  const noLayoutPaths = ["/login", "/signup"];
+
+  const isNoLayout = noLayoutPaths.includes(router.pathname);
+
+  if (isNoLayout) {
+    return <Component {...pageProps} />;
+  }
+
   return (
     <Layout>
       <Component {...pageProps} />

--- a/eatmoji/src/pages/_app.tsx
+++ b/eatmoji/src/pages/_app.tsx
@@ -1,6 +1,11 @@
+import Layout from "@/components/global-layout";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }

--- a/eatmoji/src/pages/index.module.css
+++ b/eatmoji/src/pages/index.module.css
@@ -1,0 +1,55 @@
+.container {
+  gap: 39px;
+}
+
+.logo {
+  width: 280px;
+  height: 225px;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.1));
+  transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+}
+
+.buttonStart {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 249px;
+  height: 95px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-radius: 30px;
+  background-color: #D8ED8F;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.buttonStart:hover {
+  background-color: #cfe67f;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.buttonLogin {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 160px;
+  height: 22px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.buttonLogin p {
+  color: #3f3f3f;
+  font-size: 18px;
+  font-weight: 400;
+  text-align: center;
+  text-decoration: underline;
+}
+
+.buttonLogin:hover p {
+  opacity: 0.8;
+}

--- a/eatmoji/src/pages/index.tsx
+++ b/eatmoji/src/pages/index.tsx
@@ -12,7 +12,7 @@ export default function Home() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[823px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
         <img className="w-[280px] h-[225px] shrink-0" src="/favicon_logo.png" alt="Logo" />
         <button
           type="button"

--- a/eatmoji/src/pages/index.tsx
+++ b/eatmoji/src/pages/index.tsx
@@ -1,8 +1,20 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import style from "./index.module.css";
+import sharedStyle from "@/styles/shared.module.css";
 
 export default function Home() {
   const router = useRouter();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(true);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, []);
   
   return (
     <>
@@ -12,22 +24,30 @@ export default function Home() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
-        <img className="w-[280px] h-[225px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+      <div className={`${sharedStyle.sharedContainer} ${style.container}`}>
+        <img 
+          className={style.logo} 
+          style={{
+          opacity: visible ? 1 : 0,
+          transform: visible ? "scale(1)" : "scale(0.9)",
+          }} 
+          src="/favicon_logo.png" 
+          alt="Logo" 
+        />
         <button
           type="button"
-          className="flex flex-col justify-center items-center w-[249px] h-[95px] py-[10px] rounded-[30px] bg-[#D8ED8F]"
+          className={style.buttonStart}
           onClick={() => router.push('/main')}
         >
-          <p className="text-black text-center font-inter text-[18px] font-normal leading-none">로그인없이</p>
-          <div className="text-black text-center font-inter text-[44px] font-normal leading-none">시작하기</div>  
+          <p className="text-black text-center font-inter text-[16px] font-medium tracking-wide leading-none">로그인없이</p>
+          <div className="text-black text-center font-inter text-[40px] font-semibold tracking-tight leading-none">시작하기</div>  
         </button>
         <button
           type="button"
-          className="flex flex-col justify-center items-center w-[126px] h-[22px] py-[10px]"
+          className={style.buttonLogin}
           onClick={() => router.push('/login')}
         >
-          <p className="text-black text-center font-inter text-[18px] font-normal leading-none underline">로그인/회원가입</p>
+          <p>로그인 / 회원가입</p>
         </button>
       </div>
     </>

--- a/eatmoji/src/pages/index.tsx
+++ b/eatmoji/src/pages/index.tsx
@@ -1,6 +1,9 @@
 import Head from "next/head";
+import { useRouter } from "next/router";
 
 export default function Home() {
+  const router = useRouter();
+  
   return (
     <>
       <Head>
@@ -9,9 +12,23 @@ export default function Home() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div>
-        <h1>Index Page</h1>
-        <p>Welcome to the index page of our application!</p>
+      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[823px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+        <img className="w-[280px] h-[225px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        <button
+          type="button"
+          className="flex flex-col justify-center items-center w-[249px] h-[95px] py-[10px] rounded-[30px] bg-[#D8ED8F]"
+          onClick={() => router.push('/main')}
+        >
+          <p className="text-black text-center font-inter text-[18px] font-normal leading-none">로그인없이</p>
+          <div className="text-black text-center font-inter text-[44px] font-normal leading-none">시작하기</div>  
+        </button>
+        <button
+          type="button"
+          className="flex flex-col justify-center items-center w-[126px] h-[22px] py-[10px]"
+          onClick={() => router.push('/login')}
+        >
+          <p className="text-black text-center font-inter text-[18px] font-normal leading-none underline">로그인/회원가입</p>
+        </button>
       </div>
     </>
   );

--- a/eatmoji/src/pages/login/index.tsx
+++ b/eatmoji/src/pages/login/index.tsx
@@ -1,0 +1,19 @@
+import Head from "next/head";
+
+export default function Main() {
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        로그인 페이지입니다.
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/pages/login/index.tsx
+++ b/eatmoji/src/pages/login/index.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
 
 export default function Main() {
   
@@ -10,7 +11,7 @@ export default function Main() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
         <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
         로그인 페이지입니다.
       </div>

--- a/eatmoji/src/pages/main/index.tsx
+++ b/eatmoji/src/pages/main/index.tsx
@@ -1,7 +1,60 @@
 import Head from "next/head";
+import Step1 from "@/components/main-steps/step1";
+import Step2 from "@/components/main-steps/step2";
+import Step3 from "@/components/main-steps/step3";
+import Loading from "@/components/main-steps/loading";
+import { useState } from "react";
 import sharedStyle from "@/styles/shared.module.css";
 
 export default function Main() {
+  const [step, setStep] = useState(1);
+  const [answer1, setAnswer1] = useState<string>("");
+  const [answer2, setAnswer2] = useState<string>("");
+  const [result, setResult] = useState<string | null>(null);
+
+  const nextStep = () => setStep((prev) => prev + 1);
+  const goToStep = (stepNumber: number) => setStep(stepNumber);
+
+  const handleGenerateResult = async () => {
+    setStep(3);
+
+    try {
+      const response = await fetch("/api/recommend", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ answer2 }),
+      });
+
+      if (!response.ok) {
+        throw new Error("결과를 생성하는 데 실패했습니다.");
+      }
+
+      const data = await response.json();
+      setResult(data.result);
+      setStep(4);
+    } catch (error) {
+      console.error("GPT 호출 실패:", error);
+      setResult("오류가 발생했어요. 다시 시도해 주세요.");
+      setStep(4);
+    }
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case 1:
+        return <Step1 nextStep={nextStep} setAnswer1={setAnswer1} />;
+      case 2:
+        return <Step2 nextStep={nextStep} goToStep={goToStep} setAnswer2={setAnswer2} />;
+      case 3:
+        return <Step3 answer2={answer2} generateResult={handleGenerateResult} />;
+      case 4:
+        return <Loading result={result} goToStep={goToStep} />;
+      default:
+        return null;
+    }
+  };
   
   return (
     <>

--- a/eatmoji/src/pages/main/index.tsx
+++ b/eatmoji/src/pages/main/index.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
 
 export default function Main() {
   
@@ -10,9 +11,8 @@ export default function Main() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
-        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
-        메인 페이지입니다.
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
+        {renderStep()}
       </div>
     </>
   );

--- a/eatmoji/src/pages/main/index.tsx
+++ b/eatmoji/src/pages/main/index.tsx
@@ -1,0 +1,19 @@
+import Head from "next/head";
+
+export default function Main() {
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        메인 페이지입니다.
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/pages/signup/index.tsx
+++ b/eatmoji/src/pages/signup/index.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import sharedStyle from "@/styles/shared.module.css";
 
 export default function Main() {
   
@@ -10,7 +11,7 @@ export default function Main() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
         <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
         회원가입 페이지입니다.
       </div>

--- a/eatmoji/src/pages/signup/index.tsx
+++ b/eatmoji/src/pages/signup/index.tsx
@@ -1,0 +1,19 @@
+import Head from "next/head";
+
+export default function Main() {
+  
+  return (
+    <>
+      <Head>
+        <title>Eatmoji😆</title>
+        <meta property="og:title" content="Eatmoji" />
+        <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
+        <meta property="og:image" content="/favicon_logo.png" />
+      </Head>
+      <div className="flex flex-col justify-center items-center gap-[39px] w-[411px] h-[847px] pt-[100px] px-[65px] flex-shrink-0 bg-[#FFFFFF]">
+        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
+        회원가입 페이지입니다.
+      </div>
+    </>
+  );
+}

--- a/eatmoji/src/styles/globals.css
+++ b/eatmoji/src/styles/globals.css
@@ -19,12 +19,18 @@ body {
   width: 100%;
   height: calc(var(--vh, 1vh) * 100);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
-  background-color: white;
+  background-color: #EDEDED;
   color: #111;
   font-size: 16px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -webkit-tap-highlight-color: transparent;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
 }
 
 img,
@@ -35,7 +41,6 @@ video {
 }
 
 button {
-  all: unset;
   cursor: pointer;
 }
 

--- a/eatmoji/src/styles/globals.css
+++ b/eatmoji/src/styles/globals.css
@@ -19,7 +19,7 @@ body {
   width: 100%;
   height: calc(var(--vh, 1vh) * 100);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
-  background-color: gray;
+  background-color: white;
   color: #111;
   font-size: 16px;
   line-height: 1.5;

--- a/eatmoji/src/styles/shared.module.css
+++ b/eatmoji/src/styles/shared.module.css
@@ -1,0 +1,13 @@
+.sharedContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 411px;
+  height: 847px;
+  padding-top: 30px;
+  padding-left: 65px;
+  padding-right: 65px;
+  flex-shrink: 0;
+  background-color: #FAF8F2;
+}


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feat/#2-UI-Home-및-Main-구현`
- 작업 내용 요약:
- Home 페이지 구현
![image](https://github.com/user-attachments/assets/f0df050d-622e-40e1-88da-c5d2a8b4c766)

- Main 페이지 초기화면인 step1 구현
![image](https://github.com/user-attachments/assets/49b83720-27d9-47e4-b12d-53dc0a3c8227)

- Login/Signup 페이지 생성 및 라우팅
![image](https://github.com/user-attachments/assets/52874d6f-719d-467d-9ea8-9cbef4b39ed9)
![image](https://github.com/user-attachments/assets/e5c8308a-2f87-46de-8214-157069b46676)

- global-layout으로 하단 탭 바 구현 및 css 설정
![image](https://github.com/user-attachments/assets/c9132470-e440-4ba7-8b87-41911baac922)

- sharedStyle 설정으로 전체 container 통일화
- 세부 디자인 수정

## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #2  (이슈 번호가 있다면)

## 🙋‍♂️ 리뷰어에게 한 마디
Main 페이지의 나머지 페이지 상세 구현은 Issue #4 에서 이어서 진행할 예정
