### PR TITLE
Feat/#8 UI signup 페이지 구현

### DIFF
--- a/eatmoji/src/pages/_app.tsx
+++ b/eatmoji/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
-  const noLayoutPaths = ["/login", "/signup"];
+  const noLayoutPaths = [""];
 
   const isNoLayout = noLayoutPaths.includes(router.pathname);
 

--- a/eatmoji/src/pages/signup/index.module.css
+++ b/eatmoji/src/pages/signup/index.module.css
@@ -1,0 +1,143 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem; /* gap-6 */
+  min-height: 103vh;
+  font-family: 'Inter', sans-serif;
+  padding-left: 1rem;  /* px-4 */
+  padding-right: 1rem;
+}
+
+.logo {
+  width: 180px;
+  height: 145px;
+  flex-shrink: 0;
+}
+
+.card {
+  padding: 2rem; /* 8 * 4px */
+  border-radius: 1rem; /* rounded-2xl */
+  width: 100%;
+  max-width: 24rem; /* max-w-sm */
+}
+
+.title {
+  font-size: 1.5rem; /* text-2xl */
+  font-weight: 700; /* font-bold */
+  font-family: "Roboto", sans-serif;
+  margin-bottom: 1rem; /* mb-4 */
+  text-align: center;
+}
+
+.subtitle {
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 400; /* font-normal */
+  font-family: "Roboto", sans-serif;
+  margin-bottom: 2.5rem; /* mb-10 (for step 1) or mb-6 (step 2) */
+  color: #4b5563; /* text-gray-600 */
+  text-align: center;
+}
+
+.subtitleStep2 {
+  margin-bottom: 1.5rem; /* mb-6 */
+}
+
+.checkboxGroup {
+  margin-bottom: 3.5rem; /* mb-14 */
+  display: flex;
+  flex-direction: column;
+  gap: 1rem; /* space-y-4 */
+}
+
+.checkboxItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem; /* mb-5 for 첫번째 항목 */
+  font-size: 0.875rem; /* text-sm */
+  color: #374151; /* text-gray-700 */
+}
+
+.checkboxItemLast {
+  margin-bottom: 0; /* 마지막 체크박스는 마진 제거 */
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkboxInput[type="checkbox"] {
+  accent-color: #8CC766;
+}
+
+.textLabel {
+  font-size: 0.875rem; /* text-sm */
+  color: #374151; /* text-gray-700 */
+}
+
+.button {
+  width: 100%;
+  padding: 0.75rem 0; /* py-3 */
+  border-radius: 1rem; /* rounded-xl */
+  font-family: "Roboto", sans-serif;
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 400;
+  transition: background-color 0.3s ease;
+  cursor: pointer;
+  border: none;
+  outline: none;
+}
+
+.buttonEnabled {
+  background-color: #A4D17A;
+  color: #1E2F23;
+}
+
+.buttonEnabled:hover {
+  background-color: #8CC766;
+}
+
+.buttonDisabled {
+  background-color: #d1d5db; /* gray-300 */
+  color: #6b7280; /* gray-500 */
+  cursor: not-allowed;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem; /* space-y-4 */
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+  margin-bottom: 0.25rem; /* mb-1 */
+  color: #374151; /* text-gray-700 */
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem 0.75rem; /* px-3 py-2 */
+  border: 1px solid #d1d5db; /* border-gray-300 */
+  border-radius: 1rem; /* rounded-xl */
+  font-size: 0.875rem; /* text-sm */
+  outline: none;
+  transition: box-shadow 0.2s ease;
+  font-family: inherit;
+}
+
+.input::placeholder {
+  font-size: 0.75rem; /* placeholder:text-xs */
+}
+
+.input:focus {
+  box-shadow: 0 0 0 2px #8CC766; /* focus:ring-2 focus:ring-[#151A54] */
+  border-color: #8CC766;
+}

--- a/eatmoji/src/pages/signup/index.tsx
+++ b/eatmoji/src/pages/signup/index.tsx
@@ -1,7 +1,66 @@
+/* eslint-disable @next/next/no-img-element */
 import Head from "next/head";
 import sharedStyle from "@/styles/shared.module.css";
+import { useState } from "react";
+import { useRouter } from "next/router";
+import style from "./index.module.css";
 
-export default function Main() {
+export default function Signup() {
+  type AgreementKey = "terms" | "privacy" | "marketing";
+
+  const router = useRouter();
+  const [step, setStep] = useState(1);
+  const [agreements, setAgreements] = useState({
+    terms: false,
+    privacy: false,
+    marketing: false,
+  });
+
+  const allAgreements =
+    agreements.terms && agreements.privacy && agreements.marketing;
+
+  const [form, setForm] = useState({
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+
+  const handleAgreementChange = (key: AgreementKey) => {
+    setAgreements((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleAllAgreementsChange = () => {
+    const newValue = !allAgreements;
+    setAgreements({
+      terms: newValue,
+      privacy: newValue,
+      marketing: newValue,
+    });
+  };
+
+  const isNextEnabled = agreements.terms && agreements.privacy;
+
+  const handleFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    setForm((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const isSubmitEnabled =
+    form.email.trim() !== "" &&
+    form.password.trim() !== "" &&
+    form.confirmPassword.trim() !== "" &&
+    form.password === form.confirmPassword;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (form.password !== form.confirmPassword) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+    console.log("회원가입 정보:", form);
+    alert("회원가입이 완료되었습니다!");
+    router.push("/login");
+  };
   
   return (
     <>
@@ -11,9 +70,141 @@ export default function Main() {
         <meta property="og:description" content="이모지 기반 감성 메뉴 추천 서비스" />
         <meta property="og:image" content="/favicon_logo.png" />
       </Head>
-      <div className={`${sharedStyle.sharedContainer} gap-[39px]`}>
-        <img className="w-[180px] h-[145px] shrink-0" src="/favicon_logo.png" alt="Logo" />
-        회원가입 페이지입니다.
+      <div className={`${sharedStyle.sharedContainer} ${style.container}`}>
+        <img className={style.logo} src="/favicon_logo.png" alt="Logo" />
+        
+        <div className={style.card}>
+          <h2 className={style.title}>
+              {step === 1 ? "약관 동의" : "회원가입"}
+          </h2>
+
+          {step === 1 ? (
+            <>
+              <p className={style.subtitle}>
+                  서비스 약관에 동의해 주세요
+              </p>
+              <div className={style.checkboxGroup}>
+                <div className={style.checkboxItem} style={{ marginBottom: "1.25rem" }}>
+                  <input
+                    type="checkbox"
+                    id="all-agreements"
+                    checked={allAgreements}
+                    onChange={handleAllAgreementsChange}
+                    className={style.checkboxInput}
+                  />
+                  <label htmlFor="all-agreements" className={style.textLabel}>
+                    아래의 내용을 모두 확인하였으며 모두 동의합니다.
+                  </label>
+                </div>
+                <div className={style.checkboxItemLast}>
+                  <input
+                    type="checkbox"
+                    id="terms"
+                    checked={agreements.terms}
+                    onChange={() => handleAgreementChange('terms')}
+                    className={style.checkboxInput}
+                  />
+                  <label htmlFor="terms" className={style.textLabel}>
+                    이용약관 동의 (필수)
+                  </label>
+                </div>
+                <div className={style.checkboxItemLast}>
+                  <input
+                    type="checkbox"
+                    id="privacy"
+                    checked={agreements.privacy}
+                    onChange={() => handleAgreementChange('privacy')}
+                    className={style.checkboxInput}
+                  />
+                  <label htmlFor="privacy" className={style.textLabel}>
+                    개인정보 수집 이용 동의 (필수)
+                  </label>
+                </div>
+                <div className={style.checkboxItemLast}>
+                  <input
+                    type="checkbox"
+                    id="marketing"
+                    checked={agreements.marketing}
+                    onChange={() => handleAgreementChange('marketing')}
+                    className={style.checkboxInput}
+                  />
+                  <label htmlFor="marketing" className={style.textLabel}>
+                    소식 및 이벤트 안내 수신 동의 (선택)
+                  </label>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setStep(2)}
+                disabled={!isNextEnabled}
+                className={`${style.button} ${
+                  isNextEnabled ? style.buttonEnabled : style.buttonDisabled
+                }`}
+              >
+                다음으로
+              </button>
+            </>
+          ) : (
+            <>
+              <p className={`${style.subtitle} ${style.subtitleStep2}`}>
+                회원 정보를 입력해 주세요
+              </p>
+              <form onSubmit={handleSubmit} className={style.form}>
+                <div className={style.formGroup}>
+                  <label htmlFor="email" className={style.label}>
+                    이메일
+                  </label>
+                  <input
+                    type="email"
+                    id="email"
+                    placeholder="이메일을 입력해 주세요"
+                    value={form.email}
+                    onChange={handleFormChange}
+                    className={style.input}
+                    required
+                  />
+                </div>
+                <div className={style.formGroup}>
+                  <label htmlFor="password" className={style.label}>
+                    비밀번호
+                  </label>
+                  <input
+                    type="password"
+                    id="password"
+                    placeholder="비밀번호를 입력해 주세요"
+                    value={form.password}
+                    onChange={handleFormChange}
+                    className={style.input}
+                    required
+                  />
+                </div>
+                <div className={style.formGroup}>
+                  <label htmlFor="confirmPassword" className={style.label}>
+                    비밀번호 확인
+                  </label>
+                  <input
+                    type="password"
+                    id="confirmPassword"
+                    placeholder="비밀번호를 한 번 더 입력해 주세요"
+                    value={form.confirmPassword}
+                    onChange={handleFormChange}
+                    className={style.input}
+                    required
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={!isSubmitEnabled}
+                  className={`${style.button} ${
+                    isSubmitEnabled ? style.buttonEnabled : style.buttonDisabled
+                  }`}
+                >
+                  가입하기
+                </button>
+              </form>
+            </>
+          )}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feat/#8-UI-Signup-페이지-구현`
- 작업 내용 요약:
- 회원가입 이용약관 동의 화면
![image](https://github.com/user-attachments/assets/d94842ec-cccc-44ea-a23e-99e7e7782904)
![image](https://github.com/user-attachments/assets/68c7a1f1-a03d-41cc-9163-04da9c9a5533)
- 회원가입 개인정보 입력 화면
![image](https://github.com/user-attachments/assets/0a7ec1b1-f841-49b6-99af-bee94936f6d9)
![image](https://github.com/user-attachments/assets/07956740-d857-4ff3-b66d-117299d3ddbd)


## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #8

## 🙋‍♂️ 리뷰어에게 한 마디
API 연동 및 리팩토링은 추후 예정, 일단 UI와 기본적인 기능만 작동될 수 있도록 구현함.
